### PR TITLE
Variety of Tweaks for Debugging Gov

### DIFF
--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -12,7 +12,7 @@
     "compile": "npx saddle compile",
     "test": "npx saddle compile && npx saddle test",
     "coverage": "npx saddle compile --trace && npx saddle coverage && npx istanbul report --root=./coverage lcov json",
-    "console": "npx -n --experimental-repl-await saddle console"
+    "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console"
   },
   "resolutions": {
     "solidity-parser-antlr": "https://github.com/solidity-parser/parser.git",

--- a/ethereum/saddle.config.js
+++ b/ethereum/saddle.config.js
@@ -66,6 +66,17 @@ module.exports = {
       ]
     }
   },
+  read_network_file: (network) => {
+    const fs = require('fs');
+    const path = require('path');
+    const util = require('util');
+    const env = require('process').env;
+
+    const networkFile = env['NETWORK_FILE'] || path.join(process.cwd(), 'networks', `${network}.json`);
+    return util.promisify(fs.readFile)(networkFile).then((json) => {
+      return JSON.parse(json)['Contracts'] || {};
+    });
+  },
   scripts: {
     "deploy": "deploy.js"
   }                                                     // Aliases for scripts

--- a/integration/__tests__/gov_scen.js
+++ b/integration/__tests__/gov_scen.js
@@ -11,8 +11,9 @@ let gov_scen_info = {
 
 buildScenarios('Gov Scenarios', gov_scen_info, [
   {
+    only: true,
     name: "Update Interest Rate Model by Governance",
-    scenario: async ({ ctx, zrx, chain, starport }) => {
+    scenario: async ({ ctx, zrx, chain, starport, sleep }) => {
       let newKink = {
         Kink: {
           zero_rate: 100,
@@ -22,8 +23,13 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
         }
       };
       let extrinsic = ctx.api().tx.cash.setRateModel(zrx.toChainAsset(), newKink);
-      await starport.executeProposal("Update ZRX Interest Rate Model", [extrinsic]);
-      expect(await chain.interestRateModel(zrx)).toEqual(newKink);
+      starport.executeProposal("Update ZRX Interest Rate Model", [extrinsic]);
+      // expect(await chain.interestRateModel(zrx)).toEqual(newKink);
+
+      while (true) {
+        await chain.displayBlock();
+        await sleep(1000);
+      }
     }
   },
   {

--- a/integration/__tests__/gov_scen.js
+++ b/integration/__tests__/gov_scen.js
@@ -23,13 +23,8 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
         }
       };
       let extrinsic = ctx.api().tx.cash.setRateModel(zrx.toChainAsset(), newKink);
-      starport.executeProposal("Update ZRX Interest Rate Model", [extrinsic]);
-      // expect(await chain.interestRateModel(zrx)).toEqual(newKink);
-
-      while (true) {
-        await chain.displayBlock();
-        await sleep(1000);
-      }
+      await starport.executeProposal("Update ZRX Interest Rate Model", [extrinsic]);
+      expect(await chain.interestRateModel(zrx)).toEqual(newKink);
     }
   },
   {

--- a/integration/util/scenario/chain.js
+++ b/integration/util/scenario/chain.js
@@ -134,6 +134,27 @@ class Chain {
     return await this.ctx.api().query.cash.globalCashIndex();
   }
 
+  async displayBlock() {
+    const signedBlock = await this.ctx.api().rpc.chain.getBlock();
+
+    // the information for each of the contained extrinsics
+    signedBlock.block.extrinsics.forEach((ex, index) => {
+      // the extrinsics are decoded by the API, human-like view
+      console.log(index, ex.toHuman());
+
+      const { isSigned, meta, method: { args, method, section } } = ex;
+
+      // explicit display of name, args & documentation
+      console.log(`${section}.${method}(${args.map((a) => a.toString()).join(', ')})`);
+      console.log(meta.documentation.map((d) => d.toString()).join('\n'));
+
+      // signer/nonce info
+      if (isSigned) {
+        console.log(`signer=${ex.signer.toString()}, nonce=${ex.nonce.toString()}`);
+      }
+    });
+  }
+
   async interestRateModel(token) {
     let asset = await this.ctx.api().query.cash.supportedAssets(token.toChainAsset());
     return asset.rate_model.toJSON();

--- a/integration/util/scenario/chain.js
+++ b/integration/util/scenario/chain.js
@@ -157,7 +157,7 @@ class Chain {
 
   async interestRateModel(token) {
     let asset = await this.ctx.api().query.cash.supportedAssets(token.toChainAsset());
-    return asset.rate_model.toJSON();
+    return asset.unwrap().rate_model.toJSON();
   }
 
 

--- a/integration/util/scenario/starport.js
+++ b/integration/util/scenario/starport.js
@@ -54,7 +54,7 @@ class Starport {
     return await this.starport.methods.setSupplyCap(token.ethAddress(), weiAmount).send({ from: this.ctx.eth.root() });
   }
 
-  async executeProposal(title, extrinsics, awaitEvent = true, awaitNotice = false) {
+  async executeProposal(title, extrinsics, awaitEvent = true, awaitNotice = false, checkSuccess = true) {
     let encodedCalls = extrinsics.map(encodeCall);
     let result = await this.starport.methods.executeProposal(title, encodedCalls).send({ from: this.ctx.eth.root() });
     let event;
@@ -64,6 +64,10 @@ class Starport {
     }
     if (awaitEvent) {
       event = await this.ctx.chain.waitForEthProcessEvent('cash', 'ExecutedGovernance');
+    }
+    if (checkSuccess) {
+      let [payload, govResult] = event.data[0][0];
+      expect(govResult.isDispatchSuccess).toBe(true);
     }
     return {
       event,

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -22,8 +22,8 @@ use crate::reason::Reason;
 use crate::symbol::Ticker;
 use crate::types::{
     AssetAmount, AssetBalance, AssetIndex, AssetInfo, AssetPrice, Bips, CashIndex, CashPrincipal,
-    CashPrincipalAmount, CodeHash, EncodedNotice, LiquidityFactor, Nonce, ReporterSet,
-    SessionIndex, Timestamp, ValidatorKeys, ValidatorSig,
+    CashPrincipalAmount, CodeHash, EncodedNotice, GovernanceResult, LiquidityFactor, Nonce,
+    ReporterSet, SessionIndex, Timestamp, ValidatorKeys, ValidatorSig,
 };
 use codec::alloc::string::String;
 use frame_support::{
@@ -275,7 +275,7 @@ decl_event!(
         SignedNotice(ChainId, NoticeId, EncodedNotice, ChainSignatureList),
 
         /// A sequence of governance actions has been executed. [actions]
-        ExecutedGovernance(Vec<(Vec<u8>, bool)>),
+        ExecutedGovernance(Vec<(Vec<u8>, GovernanceResult)>),
 
         /// A new supply cap has been set. [asset, cap]
         SetSupplyCap(ChainAsset, AssetAmount),

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -4,6 +4,8 @@ use our_std::{
     Deserialize, RuntimeDebug, Serialize,
 };
 
+use frame_support::sp_runtime::DispatchError;
+
 use crate::{
     chains::{Chain, ChainAsset, Ethereum},
     factor::{BigInt, BigUint, Factor},
@@ -68,6 +70,14 @@ pub type CodeHash = <Ethereum as Chain>::Hash; // XXX what to use?
 
 /// Type for an open price feed reporter.
 pub type Reporter = <Ethereum as Chain>::Address;
+
+/// Governance Result type
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+pub enum GovernanceResult {
+    FailedToDecodeCall,
+    DispatchSuccess,
+    DispatchFailure(DispatchError),
+}
 
 /// Type for a set of open price feed reporters.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug)]

--- a/types.json
+++ b/types.json
@@ -42,6 +42,13 @@
   "AccountId32": "[u8;32]",
   "AccountId": "AccountId32",
   "SubstrateId": "AccountId32",
+  "GovernanceResult": {
+    "_enum": {
+      "FailedToDecodeCall": "",
+      "DispatchSuccess": "",
+      "DispatchFailure": "(DispatchError)"
+    }
+  },
 
   "Source1": "SymbolRS",
   "Symbol": "[u8; 12]",
@@ -377,34 +384,39 @@
     "log_index": "u64",
     "event": "EthereumEvent"
   },
+  "LockEvent": {
+    "asset": "[u8; 20]",
+    "sender": "[u8; 20]",
+    "recipient": "[u8; 20]",
+    "amount": "u128"
+  },
+  "LockCashEvent": {
+    "sender": "[u8; 20]",
+    "recipient": "[u8; 20]",
+    "amount": "u128",
+    "principal": "u128"
+  },
+  "ExecTrxRequest": {
+    "account": "[u8; 20]",
+    "trx_request": "String"
+  },
+  "ExecuteProposalEvent": {
+    "title": "String",
+    "extrinsics": "Vec<Vec<u8>>"
+  },
+  "NoticeInvokedEvent": {
+    "era_id": "u32",
+    "era_index": "u32",
+    "notice_hash": "[u8; 32]",
+    "result": "Vec<u8>"
+  },
   "EthereumEvent": {
     "_enum": {
-      "Lock": {
-        "asset": "[u8; 20]",
-        "sender": "[u8; 20]",
-        "recipient": "[u8; 20]",
-        "amount": "u128"
-      },
-      "LockCash": {
-        "sender": "[u8; 20]",
-        "recipient": "[u8; 20]",
-        "amount": "u128",
-        "principal": "u128"
-      },
-      "ExecTrxRequest": {
-        "account": "[u8; 20]",
-        "trx_request": "String"
-      },
-      "ExecuteProposal": {
-        "title": "String",
-        "extrinsics": "Vec<Vec<u8>>"
-      },
-      "NoticeInvoked": {
-        "era_id": "u32",
-        "era_index": "u32",
-        "notice_hash": "[u8; 32]",
-        "result": "Vec<u8>"
-      }
+      "Lock": "LockEvent",
+      "LockCash": "LockCashEvent",
+      "ExecTrxRequest": "ExecTrxRequestEvent",
+      "ExecuteProposal": "ExecuteProposalEvent",
+      "NoticeInvoked": "NoticeInvokedEvent"
     }
   },
 


### PR DESCRIPTION
This patch just has some tweaks to help debug on-chain governance. It makes it easy to connect to ropsten in a saddle console, etc, but the best part is fixing types.json s.t. we can actually see governance passing on the test-net chain.