### PR TITLE
Upgrade via Governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ ethereum/networks/development*
 *.profraw
 lcov.info
 .vscode
+
+# Releases
+releases

--- a/integration/util/download.js
+++ b/integration/util/download.js
@@ -1,0 +1,62 @@
+const fs = require('fs').promises;
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+function getOptions(url) {
+  let u = new URL(url);
+  return {
+    host: u.hostname,
+    path: u.pathname + u.search,
+    port: u.port || (u.protocol === 'https:' ? 443 : 80),
+  };
+}
+
+function download(url, path, options = {}, handle = null) {
+  let requestOptions = {
+    ...getOptions(url),
+    ...options,
+  };
+  return new Promise(async (resolve, reject) => {
+    let f = handle || await fs.open(path, 'w');
+    let bail = false;
+    let callback = (response) => {
+      if (response.statusCode === 301 || response.statusCode === 302) {
+        let location = response.headers['location'];
+        if (!location) {
+          reject(new Error(`Redirect response does not include \`Location\` header`));
+        } else {
+          bail = true; // Nuts to you.
+          download(location, path, options, f).then(() => resolve());
+        }
+      }
+      let promises = [];
+      response.on('data', async (chunk) => {
+        if (!bail) {
+          let promise = new Promise((resolve, reject) => {
+            Promise.all(promises).then(() => {
+              f.write(chunk).then(() => resolve());
+            });
+          });
+          promises.push(promise);
+        }
+      });
+      response.on('end', async () => {
+        if (!bail) {
+          await Promise.all(promises);
+          await f.close()
+          resolve(null);
+        }
+      });
+    }
+    let req = (options.port === 80 ? http : https).request(requestOptions, callback).end();
+    req.on('error', (e) => {
+      reject(e);
+    });
+  });
+}
+
+module.exports = {
+  download
+};

--- a/integration/util/scenario/actor.js
+++ b/integration/util/scenario/actor.js
@@ -68,7 +68,7 @@ class Actor {
     let [sig, currentNonce] = await this.signWithNonce(trxReq);
     let call = this.ctx.api().tx.cash.execTrxRequest(trxReq, sig, currentNonce);
 
-    return await sendAndWaitForEvents(call, this.ctx.api(), false);
+    return await sendAndWaitForEvents(call, this.ctx.api(), { onFinalize: false });
   }
 
   async ethBalance() {
@@ -239,6 +239,10 @@ class Actors {
 
   all() {
     return this.actors;
+  }
+
+  first() {
+    return this.actors[0];
   }
 
   get(lookup) {

--- a/integration/util/scenario/chain_spec.js
+++ b/integration/util/scenario/chain_spec.js
@@ -60,6 +60,25 @@ async function baseChainSpec(validatorsInfoHash, tokensInfoHash, ctx) {
     };
   }
 
+  let frameSystem = {};
+  if (ctx.__genesisVersion()) {
+    let version = ctx.versions.mustFind(ctx.__genesisVersion());
+    frameSystem = {
+      frameSystem: {
+        code: await version.wasm()
+      }
+    };
+  }
+
+  let palletSudo = {}
+  if (ctx.actors.first()) {
+    palletSudo = {
+      palletSudo: {
+        key: ctx.actors.first().chainKey.address
+      }
+    };
+  }
+
   return {
     name: 'Integration Test Network',
     properties: {
@@ -68,6 +87,8 @@ async function baseChainSpec(validatorsInfoHash, tokensInfoHash, ctx) {
     },
     genesis: {
       runtime: {
+        ...frameSystem,
+        ...palletSudo,
         palletCash: {
           assets,
           ...initialYieldConfig,

--- a/integration/util/scenario/ctx.js
+++ b/integration/util/scenario/ctx.js
@@ -14,6 +14,7 @@ const { buildActors } = require('./actor');
 const { buildTrxReq } = require('./trx_req');
 const { buildChain } = require('./chain');
 const { buildPrices } = require('./prices');
+const { buildVersions } = require('./versions');
 
 class Ctx {
   constructor(scenInfo) {
@@ -23,6 +24,10 @@ class Ctx {
 
   __startTime() {
     return this.startTime;
+  }
+
+  __repoUrl() {
+    return process.env['REPO_URL'] || this.scenInfo['repo_url'];
   }
 
   __initialYield() {
@@ -60,11 +65,19 @@ class Ctx {
   }
 
   __target() {
-    return process.env['CHAIN_BIN'] || this.scenInfo['target'] || path.join(__dirname, '..', '..', '..', 'target', this.__profile(), 'compound-chain')
+    return process.env['CHAIN_BIN'] || this.scenInfo['target'] || path.join(__dirname, '..', '..', '..', 'target', this.__profile(), 'compound-chain');
+  }
+
+  __wasmFile() {
+    return process.env['WASM_FILE'] || this.scenInfo['wasm_file'] || path.join(__dirname, '..', '..', '..', 'target', this.__profile(), 'wbuild', 'compound-chain-runtime', 'compound_chain_runtime.compact.wasm');
+  }
+
+  __genesisVersion() {
+    return process.env['GENESIS_VERSION'] || this.scenInfo['genesis_version'];
   }
 
   __typesFile() {
-    return process.env['TYPES_FILE'] || this.scenInfo['types_file'] || path.join(__dirname, '..', '..', '..', 'types.json')
+    return process.env['TYPES_FILE'] || this.scenInfo['types_file'] || path.join(__dirname, '..', '..', '..', 'types.json');
   }
 
   __provider() {
@@ -172,6 +185,7 @@ async function buildCtx(scenInfo={}) {
   ctx.starport = await buildStarport(scenInfo.starport, scenInfo.validators, ctx);
   ctx.actors = await buildActors(scenInfo.actors, scenInfo.default_actor, ctx);
   ctx.tokens = await buildTokens(scenInfo.tokens, scenInfo, ctx);
+  ctx.versions = await buildVersions(scenInfo.versions, ctx);
   ctx.chainSpec = await buildChainSpec(scenInfo.chain_spec, scenInfo.validators, scenInfo.tokens, ctx);
   ctx.prices = await buildPrices(scenInfo.tokens, ctx);
   ctx.validators = await buildValidators(scenInfo.validators, ctx);
@@ -184,6 +198,7 @@ async function buildCtx(scenInfo={}) {
   aliasBy(ctx, ctx.actors.all(), 'name');
   aliasBy(ctx, ctx.tokens.all(), 'ticker');
   aliasBy(ctx, ctx.validators.all(), 'name');
+  aliasBy(ctx, ctx.versions.all(), 'symbolized');
 
   return ctx;
 }

--- a/integration/util/scenario/prices.js
+++ b/integration/util/scenario/prices.js
@@ -22,7 +22,7 @@ class Price {
   async post() {
     this.ctx.log(`Setting price of ${this.key}...`);
     let call = this.ctx.api().tx.cash.postPrice(this.priceInfo.payload, this.priceInfo.signature);
-    let events = await sendAndWaitForEvents(call, this.ctx.api(), true, false);
+    let events = await sendAndWaitForEvents(call, this.ctx.api(), { onFinalize: true, rejectOnFailure: false });
   }
 }
 

--- a/integration/util/scenario/scen_info.js
+++ b/integration/util/scenario/scen_info.js
@@ -30,6 +30,9 @@ const baseScenInfo = {
   cash_token: {
     liquidity_factor: 1.0,
   },
+  versions: [],
+  genesis_version: null, // [env=GENESIS_VERSION]
+  repo_url: "https://github.com/compound-finance/compound-chain", // [env=REPO_URL]
   initial_yield: 300, // [env=INITIAL_YIELD]
   initial_yield_start: null, // defaults to current time [env=INITIAL_YIELD_START]
   contracts_dir: null, // [env=BUILD_DIR]
@@ -37,6 +40,7 @@ const baseScenInfo = {
   link_validator: true, // abort if validator panics [env=LINK_VALIDATOR]
   profile: 'debug', // or debug [env=PROFILE]
   target: null, // compound-chain binary [env=CHAIN_BIN]
+  wasm_file: null, // [env=WASM_FILE]
   types_file: null, // types.json file [env=TYPES_FILE]
   opf_url: null, // use given open price feed [env=OPF_URL]
 };

--- a/integration/util/scenario/versions.js
+++ b/integration/util/scenario/versions.js
@@ -1,0 +1,197 @@
+const { download } = require('../download');
+const { instantiateInfo } = require('./scen_info');
+const { keccak256 } = require('../util');
+const fs = require('fs').promises;
+const { constants } = require('fs');
+const path = require('path');
+
+function releaseUrl(repoUrl, version, file) {
+  return `${repoUrl}/releases/download/${version}/artifacts.${file}`;
+}
+
+function baseReleasePath(version) {
+  return path.join(__dirname, '..', '..', '..', 'releases', version);
+}
+
+function releasePath(version, file) {
+  return path.join(baseReleasePath(version), file);
+}
+
+function releaseWasmInfo(repoUrl, version) {
+  return {
+    url: releaseUrl(repoUrl, version, 'compound_chain_runtime.compact.wasm'),
+    path: releasePath(version, 'compound_chain_runtime.compact.wasm'),
+  };
+}
+
+function releaseTypesInfo(repoUrl, version) {
+  return {
+    url: releaseUrl(repoUrl, version, 'types.json'),
+    path: releasePath(version, 'types.json'),
+  };
+}
+
+async function pullVersion(repoUrl, version) {
+  console.log(`Fetching version: ${version}...`);
+
+  let wasmInfo = releaseWasmInfo(repoUrl, version);
+  let typesInfo = releaseTypesInfo(repoUrl, version);
+
+  await fs.mkdir(baseReleasePath(version), { recursive: true });
+
+  await Promise.all([wasmInfo, typesInfo].map(async ({ url, path }) => {
+    console.log(`Downloading ${url} to ${path}`);
+    await download(url, path);
+  }));
+}
+
+async function checkFile(path) {
+  try {
+    await fs.access(path, constants.R_OK);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+async function checkVersion(repoUrl, version) {
+  let wasmInfo = releaseWasmInfo(repoUrl, version);
+  let typesInfo = releaseTypesInfo(repoUrl, version);
+
+  let exists = await Promise.all([wasmInfo, typesInfo].map(async ({ url, path }) => {
+    return checkFile(path);
+  }));
+
+  return exists.every((x) => x);
+}
+
+class Version {
+  constructor(version, ctx) {
+    this.version = version;
+    this.ctx = ctx;
+    this.symbolized = version.replace(/[.]/mig, '_');
+  }
+
+  matches(v) {
+    return this.version === v || this.symbolized === v;
+  }
+
+  releasePath() {
+    return baseReleasePath(this.version);
+  }
+
+  async wasm() {
+    let wasmBlob = await fs.readFile(this.wasmFile());
+    return '0x' + wasmBlob.hexSlice();
+  }
+
+  async hash() {
+    return keccak256(await this.wasm());
+  }
+
+  wasmFile() {
+    return releaseWasmInfo(this.ctx.__repoUrl(), this.version).path;
+  }
+
+  typesJson() {
+    return releaseTypesInfo(this.ctx.__repoUrl(), this.version).path;
+  }
+
+  async ensure() {
+    let exists = await this.check();
+    if (!exists) {
+      await this.pull();
+    }
+  }
+
+  async check() {
+    return await checkVersion(this.ctx.__repoUrl(), this.version);
+  }
+
+  async pull() {
+    await pullVersion(this.ctx.__repoUrl(), this.version);
+  }
+}
+
+class CurrentVersion extends Version {
+  constructor(ctx) {
+    super('curr', ctx);
+  }
+
+  async pull() {}
+
+  wasmFile() {
+    console.log({wasmFile: this.ctx.__wasmFile()});
+    return this.ctx.__wasmFile();
+  }
+
+  typesJson() {
+    return this.ctx.__typesFile();
+  }
+
+  async check() {
+    if (!await checkFile(this.wasmFile())) {
+      console.warn(`Missing wasm file at ${this.wasmFile()}`)
+    }
+
+    if (!await checkFile(this.typesJson())) {
+      console.warn(`Missing types file at ${this.typesJson()}`)
+    }
+
+    return true;
+  }
+}
+
+class Versions {
+  constructor(versions, ctx) {
+    this.versions = versions;
+    this.ctx = ctx;
+  }
+
+  all() {
+    return this.versions;
+  }
+
+  knownVersions() {
+    return this.versions.map((v) => v.version);
+  }
+
+  find(version) {
+    return this.all().find((v) => v.matches(version));
+  }
+
+  mustFind(version) {
+    let v = this.find(version);
+    if (!v) {
+      throw new Error(`Unable to find version: ${version}, found: ${JSON.stringify(this.knownVersions())}`);
+    }
+    return v;
+  }
+}
+
+async function buildVersion(version, ctx) {
+  return new Version(version, ctx);
+}
+
+async function buildVersions(versionsInfo, ctx) {
+  let versions = await versionsInfo.reduce(async (acc, versionInfo) => {
+    return [
+      ...await acc,
+      await buildVersion(versionInfo, ctx)
+    ];
+  }, Promise.resolve([]));
+
+  versions.push(new CurrentVersion(ctx));
+
+  console.log({versions});
+
+  // Make sure we have all included versions
+  await Promise.all(versions.map((version) => version.ensure()));
+
+  return new Versions(versions, ctx);
+}
+
+module.exports = {
+  buildVersions,
+  buildVersion,
+};


### PR DESCRIPTION
This patch adds versioning into integration tests, so you can fetch and run any version of Compound Chain, as well as upgrade between versions. In the first iteration of this, we simply test that you can upgrade from v0.01 to the current WASM code. However, we're halted here by the fact that 0.01 does not currently accept the final `set_next_code_via_hash` extrinsic. As such, we'll probably need to add that, cut v0.02 and then test v0.02 to curr.