### PR TITLE
Add Unit Tests for `next_code`

### DIFF
--- a/pallets/cash/src/internal/next_code.rs
+++ b/pallets/cash/src/internal/next_code.rs
@@ -1,4 +1,9 @@
-use frame_support::{storage::StorageValue, traits::UnfilteredDispatchable};
+use frame_support::{
+    dispatch::DispatchResultWithPostInfo,
+    storage::StorageValue,
+    traits::UnfilteredDispatchable,
+    weights::{Pays, PostDispatchInfo},
+};
 
 use crate::{
     chains::{Chain, Ethereum},
@@ -14,6 +19,12 @@ pub fn allow_next_code_with_hash<T: Config>(hash: CodeHash) -> Result<(), Reason
     Ok(())
 }
 
+#[cfg(not(test))]
+fn dispatch_call<T: Config>(code: Vec<u8>) -> DispatchResultWithPostInfo {
+    let call = frame_system::Call::<T>::set_code(code);
+    call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into())
+}
+
 pub fn set_next_code_via_hash<T: Config>(code: Vec<u8>) -> Result<(), Reason> {
     // XXX what Hash type to use?
     let hash = <Ethereum as Chain>::hash_bytes(&code);
@@ -22,11 +33,87 @@ pub fn set_next_code_via_hash<T: Config>(code: Vec<u8>) -> Result<(), Reason> {
         Reason::InvalidCodeHash
     );
     AllowedNextCodeHash::kill();
-    let call = frame_system::Call::<T>::set_code(code);
-    let result = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+    let result = dispatch_call::<T>(code);
     <Module<T>>::deposit_event(Event::AttemptedSetCodeByHash(
         hash,
         result.map(|_| ()).map_err(|e| e.error),
     ));
     Ok(())
+}
+
+#[cfg(test)]
+fn dispatch_call<T: Config>(_code: Vec<u8>) -> DispatchResultWithPostInfo {
+    Ok(PostDispatchInfo {
+        actual_weight: None,
+        pays_fee: Pays::No,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock;
+    use crate::mock::*;
+    use frame_support::{storage, storage::StorageValue};
+    use sp_core::storage::well_known_keys;
+
+    #[test]
+    fn test_allow_next_code_with_hash() {
+        new_test_ext().execute_with(|| {
+            assert_eq!(allow_next_code_with_hash::<Test>([1u8; 32]), Ok(()));
+            assert_eq!(AllowedNextCodeHash::get(), Some([1u8; 32]));
+        });
+    }
+
+    #[test]
+    fn test_allow_next_code_with_hash_event() {
+        new_test_ext().execute_with(|| {
+            let events_pre: Vec<_> = System::events().into_iter().collect();
+
+            assert_eq!(allow_next_code_with_hash::<Test>([1u8; 32]), Ok(()));
+
+            let events_post: Vec<_> = System::events().into_iter().collect();
+            assert_eq!(events_pre.len() + 1, events_post.len());
+
+            let allowed_next_code_hash_event = events_post.into_iter().next().unwrap();
+
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::AllowedNextCodeHash([1u8; 32])),
+                allowed_next_code_hash_event.event
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_next_code_via_hash_mismatch() {
+        new_test_ext().execute_with(|| {
+            let events_pre: Vec<_> = System::events().into_iter().collect();
+            AllowedNextCodeHash::put([1u8; 32]);
+
+            assert_eq!(
+                set_next_code_via_hash::<Test>(vec![1, 2, 3]),
+                Err(Reason::InvalidCodeHash)
+            );
+
+            let events_post: Vec<_> = System::events().into_iter().collect();
+            assert_eq!(events_pre.len(), events_post.len());
+            assert_eq!(AllowedNextCodeHash::get(), Some([1u8; 32]));
+        });
+    }
+
+    #[test]
+    fn test_set_next_code_via_hash() {
+        new_test_ext().execute_with(|| {
+            let new_code = vec![1, 2, 3];
+            let hash = <Ethereum as Chain>::hash_bytes(&new_code);
+            let events_pre: Vec<_> = System::events().into_iter().collect();
+            AllowedNextCodeHash::put(hash);
+
+            assert_eq!(set_next_code_via_hash::<Test>(new_code), Ok(()));
+
+            let events_post: Vec<_> = System::events().into_iter().collect();
+            assert_eq!(events_pre.len() + 1, events_post.len());
+            assert_eq!(AllowedNextCodeHash::get(), None);
+        });
+    }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("compound-chain"),
     impl_name: create_runtime_str!("compound-chain"),
     authoring_version: 1,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This patch adds unit tests for `next_code`. We specifically don't check the behavior of actually setting new code as that will be better accomplished by a scenario test. Thus, we feature flag off that specific call in test. Secondarily, we correct the validate_transaction code to allow calls to `set_next_code_by_hash` iff `AllowedNextCodeHash` is set.

Note: we might want to consider whether reading from storage (even just checking its existence) is too high a burden for `validate_transaction`.