### PR TITLE
remove account id from types.json

### DIFF
--- a/types.json
+++ b/types.json
@@ -40,7 +40,6 @@
   "AssetIndex": "(Uint)",
   "SessionIndex": "u32",
   "AccountId32": "[u8;32]",
-  "AccountId": "AccountId32",
   "SubstrateId": "AccountId32",
   "GovernanceResult": {
     "_enum": {


### PR DESCRIPTION
polkadot.js needs to use account id to read nonces, and this is incompatible