### PR TITLE
Allow Excess Signatures

### DIFF
--- a/ethereum/tests/starport_test.js
+++ b/ethereum/tests/starport_test.js
@@ -729,7 +729,7 @@ describe('Starport', () => {
     it('should not authorize duplicate sigs', async () => {
       const duplicateAccounts = Array(3).fill(authorityWallets[0]);
       const signatures = signAll(testUnlockNotice, duplicateAccounts);
-      await expect(call(starport, 'checkNoticeSignerAuthorized_', [testUnlockNoticeHash, authorityAddresses, signatures])).rejects.toRevert('revert Duplicated authority signer');
+      await expect(call(starport, 'checkNoticeSignerAuthorized_', [testUnlockNoticeHash, authorityAddresses, signatures])).rejects.toRevert('revert Below quorum threshold');
     });
 
     it('should not authorize with too few signatures', async () => {
@@ -740,7 +740,7 @@ describe('Starport', () => {
     it('should not authorize with an unauthorized signer', async () => {
       const badAccounts = nRandomWallets(2);
       const signatures = signAll(testUnlockNotice, badAccounts);
-      await expect(call(starport, 'checkNoticeSignerAuthorized_', [testUnlockNoticeHash, authorityAddresses, signatures])).rejects.toRevert('revert Unauthorized authority signer');
+      await expect(call(starport, 'checkNoticeSignerAuthorized_', [testUnlockNoticeHash, authorityAddresses, signatures])).rejects.toRevert('revert Below quorum threshold');
     });
   });
 


### PR DESCRIPTION
This patch is to allow the Starport to accept excess signatures-- that is, if you provide sigantures that aren't valid (either by duplication or passing in invalid signers, we do not strictly reject the notice. We simply do not count such entries and then tally the total at the end. This is to reduce frictions for users, esp. when the authorities are rotated before a notice is mined but it _might_ still have a sufficient quorum with the new authority set.

Note: should we still fail on duplicates?
Note: this is part of 1.4.1 which will improve Notices generally.